### PR TITLE
更换更加统一的图标

### DIFF
--- a/lua/statusline/provider.lua
+++ b/lua/statusline/provider.lua
@@ -117,7 +117,7 @@ end
 local function git_icons(type)
   local tbl = {
     ['added'] = ' ',
-    ['changed'] = '󰝤 ',
+    ['changed'] = ' ',
     ['deleted'] = ' ',
   }
   return tbl[type]


### PR DESCRIPTION
如图
原本的modify图标并不是圆角的
现在已经更换
![image](https://github.com/Kicamon/SimpleLine.nvim/assets/31800073/f2ea03ce-3617-4682-8213-4435141a7175)![image](https://github.com/Kicamon/SimpleLine.nvim/assets/31800073/204d07bd-2921-4bb3-b962-bc465160838b)